### PR TITLE
#52 회원가입, 로그인 기능 개선

### DIFF
--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -95,10 +95,16 @@ private extension BaseViewModel {
                 self.kakaoLoginWorker.userId { [weak self] id in
                     guard let self = self else { return }
                     let stringId = String(id)
-                    self.userDefaultsWorker.setKakaoTalkId(id: stringId)
                     self.output.kakaoAccessToken.onNext(accessToken)
                     self.output.kakaoTalkId.onNext(stringId)
-                    self.output.goToHome.accept(())
+                    self.firebaseWorker.checkIsRegisteredUser(id: stringId) { isRegistered in
+                        guard isRegistered == true else {
+                            self.output.goToSignUp.accept(())
+                            return
+                        }
+                        self.userDefaultsWorker.setKakaoTalkId(id: stringId)
+                        self.output.goToHome.accept(())
+                    }
                 }
             case .failure: ()
             }
@@ -120,12 +126,12 @@ extension BaseViewModel {
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             let userIdentifier = appleIDCredential.user
-            let fullName = appleIDCredential.fullName
-            let email = appleIDCredential.email
-            print("📌appleId : \(userIdentifier)")
-            print("📌familyName : \(fullName?.familyName ?? "")")
-            print("📌givenName : \(fullName?.givenName ?? "")")
-            print("📌email : \(email ?? "")")
+//            let fullName = appleIDCredential.fullName
+//            let email = appleIDCredential.email
+//            print("📌appleId : \(userIdentifier)")
+//            print("📌familyName : \(fullName?.familyName ?? "")")
+//            print("📌givenName : \(fullName?.givenName ?? "")")
+//            print("📌email : \(email ?? "")")
             output.appleId.onNext(userIdentifier)
         default: break
         }

--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -10,6 +10,12 @@ import Foundation
 import RxCocoa
 import RxSwift
 
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+import FirebaseRemoteConfig
+import KakaoSDKUser
+import UIKit
+
 protocol ViewModel {
 
     associatedtype Input
@@ -47,12 +53,37 @@ final class BaseViewModel: ViewModel {
 
     init() {
         // TODO: - 테스트를 위해 추가, 이후 삭제
+        testDecode()
         logoutWithKakao()
         //
 
         checkLoginId()
 
         subscribeInput()
+    }
+
+    // TODO: - Member로 디코딩 후 changeDocumentName 함수 수정
+    func testDecode() {
+        print("📌testDecode start")
+
+        let memberCollectionRef = Firestore.firestore().collection("member")
+        let docId = "2134527254"
+
+        let docRef = memberCollectionRef.document(docId)
+        docRef.getDocument { [weak self] snapshot, error in
+            if let error = error {
+                print("📌error: \(error)")
+            }
+
+            guard let self = self, let data = snapshot?.data(), let newId = Int(docId) else { return }
+            print("📌data: \(data)")
+            print("📌newId: \(newId)")
+
+            if let member = try? snapshot?.data(as: Member.self) {
+                print("📌menber: \(member)")
+            }
+
+        }
     }
 
     private func subscribeInput() {
@@ -76,7 +107,6 @@ private extension BaseViewModel {
         } else if let appleId = userDefaultsWorker.appleId(), appleId.isEmpty == false {
             print("📌appleId: \(appleId)")
             output.appleId.onNext(appleId)
-            output.goToHome.accept(())
         } else {
             print("📌UserDefaults에 저장된 id가 없음")
             output.goToSignUp.accept(())

--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -81,7 +81,7 @@ private extension BaseViewModel {
         } else if let appleId = userDefaultsWorker.appleId(), appleId.isEmpty == false {
             output.appleId.onNext(appleId)
         } else {
-            print("📌UserDefaults에 저장된 id가 없음")
+            // MARK: - UserDefaults에 저장된 id가 없음
             output.goToSignUp.accept(())
         }
     }
@@ -102,25 +102,24 @@ private extension BaseViewModel {
                     self.output.kakaoAccessToken.onNext(accessToken)
                     self.output.kakaoTalkId.onNext(kakaoId)
 
+                    // MARK: - 애플 로그인을 통해 이미 가입한 유저라면 기존 문서 이름 변경
                     if let appleId = try? self.output.appleId.value() {
-                        print("📌appleId: \(appleId)")
-
                         self.firebaseWorker.changeMemberDocumentName(appleId, to: kakaoId) { result in
                             switch result {
-                            case .success: print("📌문서 불러오기 성공")
-                            case .failure: print("📌문서 불러오기 실패")
+                            case .success: self.output.goToHome.accept(())
+                            case .failure: self.output.goToSignUp.accept(())
                             }
                         }
                     }
 
                     // MARK: - 이미 가입한 카카오톡 유저인지 확인
                     self.firebaseWorker.checkIsRegisteredUser(id: kakaoId) { isRegistered in
+                        // MARK: - 가입하지 않은 카카오톡 유저
                         guard isRegistered == true else {
-                            print("📌가입하지 않은 카카오톡 유저 \(kakaoId)")
                             self.output.goToSignUp.accept(())
                             return
                         }
-                        print("📌이미 가입한 카카오톡 유저")
+                        // MARK: - 이미 가입한 카카오톡 유저
                         self.userDefaultsWorker.setKakaoTalkId(id: kakaoId)
                         self.output.goToHome.accept(())
 
@@ -136,7 +135,6 @@ private extension BaseViewModel {
     }
 
     func logoutWithKakao() {
-        print("📌카카오톡 로그아웃")
         kakaoLoginWorker.logoutWithKakao()
         userDefaultsWorker.removeKakaoTalkId()
     }
@@ -154,12 +152,12 @@ extension BaseViewModel {
 //            let email = appleIDCredential.email
             output.appleId.onNext(userIdentifier)
             self.firebaseWorker.checkIsRegisteredUser(id: userIdentifier) { isRegistered in
+                // MARK: - 가입하지 않은 애플 유저
                 guard isRegistered == true else {
-                    print("📌가입하지 않은 애플 유저")
                     self.output.goToSignUp.accept(())
                     return
                 }
-                print("📌이미 가입한 애플 유저")
+                // MARK: - 이미 가입한 애플 유저
                 self.userDefaultsWorker.setAppleId(id: userIdentifier)
                 self.output.goToHome.accept(())
             }

--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -46,7 +46,7 @@ final class BaseViewModel: ViewModel {
     private let userDefaultsWorker = UserDefaultsWorker()
 
     init() {
-        // TODO: - 테스트를 위해 추가
+        // TODO: - 테스트를 위해 추가, 이후 삭제
         logoutWithKakao()
         //
 

--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -72,12 +72,13 @@ private extension BaseViewModel {
             print("📌kakaoTalkId: \(kakaoTalkId)")
             output.kakaoTalkId.onNext(kakaoTalkId)
             output.goToHome.accept(())
+            return
         } else if let appleId = userDefaultsWorker.appleId(), appleId.isEmpty == false {
             print("📌appleId: \(appleId)")
             output.appleId.onNext(appleId)
             output.goToHome.accept(())
         } else {
-            print("📌no id")
+            print("📌UserDefaults에 저장된 id가 없음")
             output.goToSignUp.accept(())
         }
     }
@@ -111,8 +112,12 @@ private extension BaseViewModel {
         }
     }
 
+    func checkIsRegisteredUser(id: String) {
+
+    }
+
     func logoutWithKakao() {
-        print("📌logoutWithKakao")
+        print("📌카카오톡 로그아웃")
         kakaoLoginWorker.logoutWithKakao()
         userDefaultsWorker.removeKakaoTalkId()
     }
@@ -128,11 +133,17 @@ extension BaseViewModel {
             let userIdentifier = appleIDCredential.user
 //            let fullName = appleIDCredential.fullName
 //            let email = appleIDCredential.email
-//            print("📌appleId : \(userIdentifier)")
-//            print("📌familyName : \(fullName?.familyName ?? "")")
-//            print("📌givenName : \(fullName?.givenName ?? "")")
-//            print("📌email : \(email ?? "")")
             output.appleId.onNext(userIdentifier)
+            self.firebaseWorker.checkIsRegisteredUser(id: userIdentifier) { isRegistered in
+                guard isRegistered == true else {
+                    print("📌가입하지 않은 애플 유저")
+                    self.output.goToSignUp.accept(())
+                    return
+                }
+                print("📌이미 가입한 애플 유저")
+                self.userDefaultsWorker.setAppleId(id: userIdentifier)
+                self.output.goToHome.accept(())
+            }
         default: break
         }
     }

--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -98,13 +98,30 @@ private extension BaseViewModel {
                     let stringId = String(id)
                     self.output.kakaoAccessToken.onNext(accessToken)
                     self.output.kakaoTalkId.onNext(stringId)
+
+                    print("📌카카오톡 로그인 시도중")
+
+                    // TODO: - 애플 로그인 id값이 있으면 문서 수정하고 홈으로 이동
+                    if let appleId = try? self.output.appleId.value() {
+                        self.firebaseWorker.getMemberDocument(id: appleId) { result in
+                            switch result {
+                            case .success(let word): print("📌word: \(word)")
+                            case .failure: ()
+                            }
+                        }
+                    }
+
+                    // MARK: - 이미 가입한 카카오톡 유저인지 확인
                     self.firebaseWorker.checkIsRegisteredUser(id: stringId) { isRegistered in
                         guard isRegistered == true else {
+                            print("📌가입하지 않은 카카오톡 유저 \(stringId)")
                             self.output.goToSignUp.accept(())
                             return
                         }
+                        print("📌이미 가입한 카카오톡 유저")
                         self.userDefaultsWorker.setKakaoTalkId(id: stringId)
                         self.output.goToHome.accept(())
+
                     }
                 }
             case .failure: ()

--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -95,31 +95,33 @@ private extension BaseViewModel {
             case .success(let accessToken):
                 self.kakaoLoginWorker.userId { [weak self] id in
                     guard let self = self else { return }
-                    let stringId = String(id)
+                    let kakaoId = String(id)
                     self.output.kakaoAccessToken.onNext(accessToken)
-                    self.output.kakaoTalkId.onNext(stringId)
+                    self.output.kakaoTalkId.onNext(kakaoId)
 
                     print("📌카카오톡 로그인 시도중")
 
                     // TODO: - 애플 로그인 id값이 있으면 문서 수정하고 홈으로 이동
                     if let appleId = try? self.output.appleId.value() {
-                        self.firebaseWorker.getMemberDocument(id: appleId) { result in
+                        print("📌appleId: \(appleId)")
+
+                        self.firebaseWorker.changeDocumentName(appleId, to: kakaoId) { result in
                             switch result {
-                            case .success(let word): print("📌word: \(word)")
-                            case .failure: ()
+                            case .success(let word): print("📌문서 불러오기: \(word)")
+                            case .failure: print("📌문서 불러오기 실패")
                             }
                         }
                     }
 
                     // MARK: - 이미 가입한 카카오톡 유저인지 확인
-                    self.firebaseWorker.checkIsRegisteredUser(id: stringId) { isRegistered in
+                    self.firebaseWorker.checkIsRegisteredUser(id: kakaoId) { isRegistered in
                         guard isRegistered == true else {
-                            print("📌가입하지 않은 카카오톡 유저 \(stringId)")
+                            print("📌가입하지 않은 카카오톡 유저 \(kakaoId)")
                             self.output.goToSignUp.accept(())
                             return
                         }
                         print("📌이미 가입한 카카오톡 유저")
-                        self.userDefaultsWorker.setKakaoTalkId(id: stringId)
+                        self.userDefaultsWorker.setKakaoTalkId(id: kakaoId)
                         self.output.goToHome.accept(())
 
                     }

--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -24,14 +24,13 @@ protocol ViewModel {
 final class BaseViewModel: ViewModel {
 
     struct Input {
-//        let tapAppleLogin = PublishRelay<Void>()
         let tapKakaoTalkLogin = PublishRelay<Void>()
     }
 
     struct Output {
+        let kakaoAccessToken = PublishSubject<String>()
         let kakaoTalkId = BehaviorSubject<String>(value: "")
         let appleId = BehaviorSubject<String>(value: "")
-        let accessToken = PublishSubject<String>()
 
         let goToSignUp = PublishRelay<Void>()
         let goToHome = PublishRelay<Void>()
@@ -47,7 +46,8 @@ final class BaseViewModel: ViewModel {
     private let userDefaultsWorker = UserDefaultsWorker()
 
     init() {
-        logoutWithKakao() // TODO: - 테스트 위해 추가
+        // TODO: - 테스트를 위해 로그아웃함
+        logoutWithKakao()
         checkLoginId()
 
         subscribeInput()
@@ -58,11 +58,6 @@ final class BaseViewModel: ViewModel {
             .subscribe(onNext: { [weak self] _ in
                 self?.loginWithKakao()
             }).disposed(by: disposeBag)
-
-//        input.tapAppleLogin
-//            .subscribe(onNext: { [weak self] _ in
-//                self?.loginWithApple()
-//            }).disposed(by: disposeBag)
     }
 
 }
@@ -98,7 +93,7 @@ private extension BaseViewModel {
                 self.kakaoLoginWorker.userId { [weak self] id in
                     guard let self = self else { return }
                     print("📌id: \(id)")
-                    self.output.accessToken.onNext(accessToken)
+                    self.output.kakaoAccessToken.onNext(accessToken)
                     self.userDefaultsWorker.setKakaoTalkId(id: String(id))
                 }
             case .failure: ()

--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -46,8 +46,10 @@ final class BaseViewModel: ViewModel {
     private let userDefaultsWorker = UserDefaultsWorker()
 
     init() {
-        // TODO: - 테스트를 위해 로그아웃함
+        // TODO: - 테스트를 위해 추가
         logoutWithKakao()
+        //
+
         checkLoginId()
 
         subscribeInput()
@@ -92,9 +94,11 @@ private extension BaseViewModel {
             case .success(let accessToken):
                 self.kakaoLoginWorker.userId { [weak self] id in
                     guard let self = self else { return }
-                    print("📌id: \(id)")
+                    let stringId = String(id)
+                    self.userDefaultsWorker.setKakaoTalkId(id: stringId)
                     self.output.kakaoAccessToken.onNext(accessToken)
-                    self.userDefaultsWorker.setKakaoTalkId(id: String(id))
+                    self.output.kakaoTalkId.onNext(stringId)
+                    self.output.goToHome.accept(())
                 }
             case .failure: ()
             }
@@ -102,7 +106,9 @@ private extension BaseViewModel {
     }
 
     func logoutWithKakao() {
+        print("📌logoutWithKakao")
         kakaoLoginWorker.logoutWithKakao()
+        userDefaultsWorker.removeKakaoTalkId()
     }
 
 }
@@ -116,7 +122,7 @@ extension BaseViewModel {
             let userIdentifier = appleIDCredential.user
             let fullName = appleIDCredential.fullName
             let email = appleIDCredential.email
-            print("📌id : \(userIdentifier)")
+            print("📌appleId : \(userIdentifier)")
             print("📌familyName : \(fullName?.familyName ?? "")")
             print("📌givenName : \(fullName?.givenName ?? "")")
             print("📌email : \(email ?? "")")

--- a/attendance-ios/Source/BaseViewModel.swift
+++ b/attendance-ios/Source/BaseViewModel.swift
@@ -53,37 +53,12 @@ final class BaseViewModel: ViewModel {
 
     init() {
         // TODO: - 테스트를 위해 추가, 이후 삭제
-        testDecode()
         logoutWithKakao()
         //
 
         checkLoginId()
 
         subscribeInput()
-    }
-
-    // TODO: - Member로 디코딩 후 changeDocumentName 함수 수정
-    func testDecode() {
-        print("📌testDecode start")
-
-        let memberCollectionRef = Firestore.firestore().collection("member")
-        let docId = "2134527254"
-
-        let docRef = memberCollectionRef.document(docId)
-        docRef.getDocument { [weak self] snapshot, error in
-            if let error = error {
-                print("📌error: \(error)")
-            }
-
-            guard let self = self, let data = snapshot?.data(), let newId = Int(docId) else { return }
-            print("📌data: \(data)")
-            print("📌newId: \(newId)")
-
-            if let member = try? snapshot?.data(as: Member.self) {
-                print("📌menber: \(member)")
-            }
-
-        }
     }
 
     private func subscribeInput() {
@@ -100,12 +75,10 @@ private extension BaseViewModel {
 
     func checkLoginId() {
         if let kakaoTalkId = userDefaultsWorker.kakaoTalkId(), kakaoTalkId.isEmpty == false {
-            print("📌kakaoTalkId: \(kakaoTalkId)")
             output.kakaoTalkId.onNext(kakaoTalkId)
             output.goToHome.accept(())
             return
         } else if let appleId = userDefaultsWorker.appleId(), appleId.isEmpty == false {
-            print("📌appleId: \(appleId)")
             output.appleId.onNext(appleId)
         } else {
             print("📌UserDefaults에 저장된 id가 없음")
@@ -129,15 +102,12 @@ private extension BaseViewModel {
                     self.output.kakaoAccessToken.onNext(accessToken)
                     self.output.kakaoTalkId.onNext(kakaoId)
 
-                    print("📌카카오톡 로그인 시도중")
-
-                    // TODO: - 애플 로그인 id값이 있으면 문서 수정하고 홈으로 이동
                     if let appleId = try? self.output.appleId.value() {
                         print("📌appleId: \(appleId)")
 
-                        self.firebaseWorker.changeDocumentName(appleId, to: kakaoId) { result in
+                        self.firebaseWorker.changeMemberDocumentName(appleId, to: kakaoId) { result in
                             switch result {
-                            case .success(let word): print("📌문서 불러오기: \(word)")
+                            case .success: print("📌문서 불러오기 성공")
                             case .failure: print("📌문서 불러오기 실패")
                             }
                         }

--- a/attendance-ios/Source/Login/LoginViewController.swift
+++ b/attendance-ios/Source/Login/LoginViewController.swift
@@ -123,6 +123,18 @@ private extension LoginViewController {
     }
 
     func bindViewModel() {
+        viewModel.output.kakaoTalkId
+            .subscribe(onNext: { [weak self] id in
+                guard id.isEmpty == false else { return }
+                self?.goToHomeVC()
+            }).disposed(by: disposeBag)
+
+        viewModel.output.appleId
+            .subscribe(onNext: { [weak self] id in
+                guard id.isEmpty == false else { return }
+                self?.goToHomeVC()
+            }).disposed(by: disposeBag)
+
         viewModel.output.goToSignUp
             .observe(on: MainScheduler.instance)
             .bind(onNext: goToSignUpNameVC)

--- a/attendance-ios/Source/Login/LoginViewController.swift
+++ b/attendance-ios/Source/Login/LoginViewController.swift
@@ -123,18 +123,6 @@ private extension LoginViewController {
     }
 
     func bindViewModel() {
-        viewModel.output.kakaoTalkId
-            .subscribe(onNext: { [weak self] id in
-                guard id.isEmpty == false else { return }
-                self?.goToHomeVC()
-            }).disposed(by: disposeBag)
-
-        viewModel.output.appleId
-            .subscribe(onNext: { [weak self] id in
-                guard id.isEmpty == false else { return }
-                self?.goToHomeVC()
-            }).disposed(by: disposeBag)
-
         viewModel.output.goToSignUp
             .observe(on: MainScheduler.instance)
             .bind(onNext: goToSignUpNameVC)

--- a/attendance-ios/Source/Model/Attendance.swift
+++ b/attendance-ios/Source/Model/Attendance.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct Attendance: Codable {
-    let sesstionId: Int
+    let sessionId: Int
     let type: AttendanceType
 }
 

--- a/attendance-ios/Source/Model/Attendance.swift
+++ b/attendance-ios/Source/Model/Attendance.swift
@@ -12,7 +12,12 @@ struct Attendance: Codable {
     let type: AttendanceType
 }
 
-enum AttendanceType: Int, Codable {
+struct AttendanceType: Codable {
+    let point: Int
+    let text: String
+}
+
+enum AttendanceCase: Int, Codable {
     case absence
     case tardy
     case attendance

--- a/attendance-ios/Source/Model/Models.swift
+++ b/attendance-ios/Source/Model/Models.swift
@@ -57,17 +57,51 @@ struct Team: Codable {
 }
 
 enum TeamType: String, Codable {
-    case android = "Android"
-    case ios = "iOS"
-    case web = "Web"
-    case allRounder = "All-Rounder"
+    case android = "ANDROID"
+    case ios = "IOS"
+    case web = "WEB"
+    case allRounder = "ALL_ROUNDER"
 
-    var upperCase: String {
+    var lowerCase: String {
         switch self {
-        case .android: return "ANDROID"
-        case .ios: return "IOS"
-        case .web: return "WEB"
-        case .allRounder: return "ALL_ROUNDER"
+        case .android: return "Android"
+        case .ios: return "iOS"
+        case .web: return "Web"
+        case .allRounder: return "All-Rounder"
         }
     }
+
 }
+
+//enum TeamType: String, Codable {
+//    case android
+//    case ios
+//    case web
+//    case allRounder
+//
+//    var upperCase: String {
+//        switch self {
+//        case .android: return "ANDROID"
+//        case .ios: return "IOS"
+//        case .web: return "WEB"
+//        case .allRounder: return "ALL_ROUNDER"
+//        }
+//    }
+//
+//    var lowerCase: String {
+//        switch self {
+//        case .android: return "Android"
+//        case .ios: return "iOS"
+//        case .web: return "Web"
+//        case .allRounder: return "All-Rounder"
+//        }
+//    }
+//
+//    enum CodingKeys: String, CodingKey {
+//        case android = "ANDROID"
+//        case ios = "IOS"
+//        case web = "WEB"
+//        case allRounder = "ALL_ROUNDER"
+//    }
+//
+//}

--- a/attendance-ios/Source/Model/Models.swift
+++ b/attendance-ios/Source/Model/Models.swift
@@ -62,6 +62,15 @@ enum TeamType: String, Codable {
     case web = "WEB"
     case allRounder = "ALL_ROUNDER"
 
+    var upperCase: String {
+        switch self {
+        case .android: return "ANDROID"
+        case .ios: return "IOS"
+        case .web: return "WEB"
+        case .allRounder: return "ALL_ROUNDER"
+        }
+    }
+
     var lowerCase: String {
         switch self {
         case .android: return "Android"
@@ -72,36 +81,3 @@ enum TeamType: String, Codable {
     }
 
 }
-
-//enum TeamType: String, Codable {
-//    case android
-//    case ios
-//    case web
-//    case allRounder
-//
-//    var upperCase: String {
-//        switch self {
-//        case .android: return "ANDROID"
-//        case .ios: return "IOS"
-//        case .web: return "WEB"
-//        case .allRounder: return "ALL_ROUNDER"
-//        }
-//    }
-//
-//    var lowerCase: String {
-//        switch self {
-//        case .android: return "Android"
-//        case .ios: return "iOS"
-//        case .web: return "Web"
-//        case .allRounder: return "All-Rounder"
-//        }
-//    }
-//
-//    enum CodingKeys: String, CodingKey {
-//        case android = "ANDROID"
-//        case ios = "IOS"
-//        case web = "WEB"
-//        case allRounder = "ALL_ROUNDER"
-//    }
-//
-//}

--- a/attendance-ios/Source/SignUp/SignUpTeamViewController.swift
+++ b/attendance-ios/Source/SignUp/SignUpTeamViewController.swift
@@ -235,7 +235,7 @@ extension SignUpTeamViewController: UICollectionViewDelegateFlowLayout, UICollec
 
         switch collectionView {
         case teamTypeCollectionView:
-            cell.configureUI(text: teams[indexPath.row].type.rawValue)
+            cell.configureUI(text: teams[indexPath.row].type.lowerCase)
         case teamNumberCollectionView:
             cell.configureUI(text: "\(indexPath.row+1)팀")
             guard let teamNumber = try? viewModel.input.teamNumber.value() else { break }
@@ -253,7 +253,7 @@ extension SignUpTeamViewController: UICollectionViewDelegateFlowLayout, UICollec
         switch collectionView {
         case teamTypeCollectionView:
             guard let teams = try? viewModel.output.configTeams.value() else { break }
-            text = teams[indexPath.row].type.rawValue
+            text = teams[indexPath.row].type.lowerCase
         case teamNumberCollectionView: text = "\(indexPath.row+1)팀"
         default: ()
         }

--- a/attendance-ios/Source/SignUp/SignUpViewModel.swift
+++ b/attendance-ios/Source/SignUp/SignUpViewModel.swift
@@ -110,7 +110,7 @@ extension SignUpViewModel {
               let teamType = try? input.teamType.value(),
               let teamNumber = try? input.teamNumber.value() else { return }
 
-        let newUser = FirebaseNewUser(name: name, positionType: positionType, teamType: teamType, teamNumber: teamNumber)
+        let newUser = FirebaseNewMember(name: name, positionType: positionType, teamType: teamType, teamNumber: teamNumber)
 
         if kakaoTalkId.isEmpty == false {
             guard let id = Int(kakaoTalkId) else { return }

--- a/attendance-ios/Source/SignUp/SignUpViewModel.swift
+++ b/attendance-ios/Source/SignUp/SignUpViewModel.swift
@@ -55,16 +55,6 @@ final class SignUpViewModel: ViewModel {
 private extension SignUpViewModel {
 
     func bindInput() {
-        input.kakaoTalkId
-            .subscribe(onNext: { [weak self] id in
-                print("kakaoTalkId: \(id)")
-            }).disposed(by: disposeBag)
-
-        input.appleId
-            .subscribe(onNext: { [weak self] id in
-                print("appleId: \(id)")
-            }).disposed(by: disposeBag)
-
         input.name
             .subscribe(onNext: { [weak self] name in
                 self?.output.isNameTextFieldValid.onNext(name?.isEmpty == false)
@@ -84,14 +74,6 @@ private extension SignUpViewModel {
             .subscribe(onNext: { [weak self] _ in
                 self?.registerInfo()
             }).disposed(by: disposeBag)
-    }
-
-    func setLoginId() {
-        guard let appleId = try? input.appleId.value(),
-              let kakaoTalkId = try? input.kakaoTalkId.value() else { return }
-
-        userDefaultsWorker.set(appleId, forKey: .appleId)
-        userDefaultsWorker.set(kakaoTalkId, forKey: .kakaoTalkId)
     }
 
 }
@@ -130,28 +112,16 @@ extension SignUpViewModel {
 
         let newUser = FirebaseNewUser(name: name, positionType: positionType, teamType: teamType, teamNumber: teamNumber)
 
-        // TODO: - getDocument 함수 만들기
-        if kakaoTalkId.isEmpty == false, appleId.isEmpty == false {
-//            firebaseWorker.checkIsRegisteredUser(id: kakaoTalkId) { isRegistered in
-//                switch result {
-//                case .success(let hasDocument):
-//                    if hasDocument == false {
-//                        // TODO: - appId에 해당하는 문서를 찾아 kakaoTalkId로 변경한다.
-//                    }
-//                case .failure: ()
-//                }
-//            }
-        }
-
         if kakaoTalkId.isEmpty == false {
-            firebaseWorker.registerInfo(id: kakaoTalkId, newUser: newUser) { [weak self] result in
+            guard let id = Int(kakaoTalkId) else { return }
+            firebaseWorker.registerKakaoUserInfo(id: id, newUser: newUser) { [weak self] result in
                 switch result {
                 case .success: self?.output.goToHome.accept(())
                 case .failure: ()
                 }
             }
         } else if appleId.isEmpty == false {
-            firebaseWorker.registerInfo(id: appleId, newUser: newUser) { [weak self] result in
+            firebaseWorker.registerAppleUserInfo(id: appleId, newUser: newUser) { [weak self] result in
                 switch result {
                 case .success: self?.output.goToHome.accept(())
                 case .failure: ()

--- a/attendance-ios/Source/SignUp/SignUpViewModel.swift
+++ b/attendance-ios/Source/SignUp/SignUpViewModel.swift
@@ -123,7 +123,9 @@ extension SignUpViewModel {
         } else if appleId.isEmpty == false {
             firebaseWorker.registerAppleUserInfo(id: appleId, newUser: newUser) { [weak self] result in
                 switch result {
-                case .success: self?.output.goToHome.accept(())
+                case .success:
+                    self?.userDefaultsWorker.setAppleId(id: appleId)
+                    self?.output.goToHome.accept(())
                 case .failure: ()
                 }
             }

--- a/attendance-ios/Source/SignUp/SignUpViewModel.swift
+++ b/attendance-ios/Source/SignUp/SignUpViewModel.swift
@@ -130,16 +130,17 @@ extension SignUpViewModel {
 
         let newUser = FirebaseNewUser(name: name, positionType: positionType, teamType: teamType, teamNumber: teamNumber)
 
+        // TODO: - getDocument 함수 만들기
         if kakaoTalkId.isEmpty == false, appleId.isEmpty == false {
-            firebaseWorker.hasDocument(id: kakaoTalkId) { result in
-                switch result {
-                case .success(let hasDocument):
-                    if hasDocument == false {
-                        // TODO: - appId에 해당하는 문서를 찾아 kakaoTalkId로 변경한다.
-                    }
-                case .failure: ()
-                }
-            }
+//            firebaseWorker.checkIsRegisteredUser(id: kakaoTalkId) { isRegistered in
+//                switch result {
+//                case .success(let hasDocument):
+//                    if hasDocument == false {
+//                        // TODO: - appId에 해당하는 문서를 찾아 kakaoTalkId로 변경한다.
+//                    }
+//                case .failure: ()
+//                }
+//            }
         }
 
         if kakaoTalkId.isEmpty == false {

--- a/attendance-ios/Source/Utilities/ConfigWorker.swift
+++ b/attendance-ios/Source/Utilities/ConfigWorker.swift
@@ -45,7 +45,6 @@ final class ConfigWorker {
         }
     }
 
-    // TODO: - 
     /// 선택할 팀 배열을 반환합니다.
     func decodeSelectTeams(completion: @escaping (Result<[Team], Error>) -> Void) {
         remoteConfig.fetch { [weak self] status, _ in

--- a/attendance-ios/Source/Utilities/ConfigWorker.swift
+++ b/attendance-ios/Source/Utilities/ConfigWorker.swift
@@ -45,6 +45,7 @@ final class ConfigWorker {
         }
     }
 
+    // TODO: - 
     /// 선택할 팀 배열을 반환합니다.
     func decodeSelectTeams(completion: @escaping (Result<[Team], Error>) -> Void) {
         remoteConfig.fetch { [weak self] status, _ in

--- a/attendance-ios/Source/Utilities/FirebaseWorker.swift
+++ b/attendance-ios/Source/Utilities/FirebaseWorker.swift
@@ -12,7 +12,7 @@ import UIKit
 
 final class FirebaseWorker {
 
-    private let docRef = Firestore.firestore().collection("member")
+    private let memberDocRef = Firestore.firestore().collection("member")
 
 }
 
@@ -27,7 +27,7 @@ struct FirebaseNewUser {
 extension FirebaseWorker {
 
     func registerInfo(id: String, newUser: FirebaseNewUser, completion: @escaping (Result<Void, Error>) -> Void) {
-        docRef.document("\(id)").setData([
+        memberDocRef.document("\(id)").setData([
             "id": id,
             "name": newUser.name,
             "position": newUser.positionType.rawValue,
@@ -58,7 +58,7 @@ extension FirebaseWorker {
 extension FirebaseWorker {
 
     /// 카카오톡으로 로그인한 유저의 문서를 삭제합니다.
-    func deleteUserInfo() {
+    func deleteKakaoTalkUserInfo() {
         UserApi.shared.me { [weak self] user, _ in
             guard let self = self, let userId = user?.id else { return }
             self.deleteDocument(id: String(userId))
@@ -67,7 +67,7 @@ extension FirebaseWorker {
 
     /// 문서를 삭제합니다.
     func deleteDocument(id: String) {
-        docRef.document(id).delete()
+        memberDocRef.document(id).delete()
     }
 
 }
@@ -75,8 +75,9 @@ extension FirebaseWorker {
 // MARK: - Read
 extension FirebaseWorker {
 
-    func getDocumentIdList(completion: @escaping (Result<[String], Error>) -> Void) {
-        docRef.getDocuments { snapshot, error in
+    /// 맴버 문서 id 배열을 반환합니다.
+    func getMemberDocumentIdList(completion: @escaping (Result<[String], Error>) -> Void) {
+        memberDocRef.getDocuments { snapshot, error in
             if let error = error {
                 completion(.failure(error))
             }
@@ -86,8 +87,9 @@ extension FirebaseWorker {
         }
     }
 
-    func checkIsExistingUser(id: String, completion: @escaping (Bool) -> Void) {
-        getDocumentIdList { result in
+    /// 이미 가입한 유저인지 확인합니다.
+    func checkIsRegisteredUser(id: String, completion: @escaping (Bool) -> Void) {
+        getMemberDocumentIdList { result in
             switch result {
             case .success(let idList): completion(idList.contains(id))
             case .failure: completion(false)
@@ -95,13 +97,9 @@ extension FirebaseWorker {
         }
     }
 
-    func hasDocument(id: String, completion: @escaping (Result<Bool, Error>) -> Void) {
-        getDocumentIdList { result in
-            switch result {
-            case .success(let list): completion(.success(list.contains(id)))
-            case .failure(let error): completion(.failure(error))
-            }
-        }
+    /// 문서를 반환합니다.
+    func getDocument() {
+
     }
 
 }

--- a/attendance-ios/Source/Utilities/FirebaseWorker.swift
+++ b/attendance-ios/Source/Utilities/FirebaseWorker.swift
@@ -32,7 +32,7 @@ extension FirebaseWorker {
             "id": id,
             "name": newUser.name,
             "position": newUser.positionType.rawValue,
-            "team": ["number": newUser.teamNumber, "type": newUser.teamType.upperCase],
+            "team": ["number": newUser.teamNumber, "type": newUser.teamType.rawValue],
             "attendances": self.makeEmptyAttendances()
         ]) { error in
             guard let error = error else {
@@ -48,7 +48,7 @@ extension FirebaseWorker {
             "id": Int.random(in: 1000000000..<10000000000),
             "name": newUser.name,
             "position": newUser.positionType.rawValue,
-            "team": ["number": newUser.teamNumber, "type": newUser.teamType.upperCase],
+            "team": ["number": newUser.teamNumber, "type": newUser.teamType.rawValue],
             "attendances": self.makeEmptyAttendances()
         ]) { error in
             guard let error = error else {
@@ -115,18 +115,22 @@ extension FirebaseWorker {
     }
 
     /// 문서 이름을 애플 아이디에서 카카오톡 아이디로 변경합니다.
-    func changeDocumentName(_ appleId: String, to kakaoId: String, completion: @escaping (Result<Attendance, Error>) -> Void) {
+    func changeDocumentName(_ appleId: String, to kakaoId: String, completion: @escaping (Result<Member, Error>) -> Void) {
         let docRef = memberCollectionRef.document(appleId)
         docRef.getDocument { [weak self] snapshot, error in
             if let error = error {
                 completion(.failure(error))
             }
             guard let self = self, let data = snapshot?.data(), let newId = Int(kakaoId) else { return }
-            print("📌data: \(data)")
             print("📌newId: \(newId)")
 
-            // TODO: - 임의의 FirebaseNewUser 정보로 변경 필요
-            let newUser = FirebaseNewUser(name: "기존 애플 유저 파일 이동 테스트", positionType: .ios, teamType: .ios, teamNumber: 1)
+            // TODO: - 문서의 Member 정보로 newUser 수정해 문서 생성하기
+            if let menber = try? snapshot?.data(as: Member.self) {
+                print("📌menber: \(menber)")
+            }
+            print("📌data: \(data)")
+
+            let newUser = FirebaseNewUser(name: "기존 애플 유저 파일명 변경", positionType: .ios, teamType: .ios, teamNumber: 1)
             self.registerKakaoUserInfo(id: newId, newUser: newUser) { result in
                 switch result {
                 case .success: self.deleteDocument(id: appleId)

--- a/attendance-ios/Source/Utilities/FirebaseWorker.swift
+++ b/attendance-ios/Source/Utilities/FirebaseWorker.swift
@@ -98,7 +98,7 @@ extension FirebaseWorker {
                 completion(.failure(error))
             }
             guard let documents = snapshot?.documents else { return }
-            let idList = documents.map { $0.data() }.compactMap { $0["id"] as? String }
+            let idList = documents.map { $0.documentID }
             completion(.success(idList))
         }
     }

--- a/attendance-ios/Source/Utilities/FirebaseWorker.swift
+++ b/attendance-ios/Source/Utilities/FirebaseWorker.swift
@@ -26,9 +26,25 @@ struct FirebaseNewUser {
 
 extension FirebaseWorker {
 
-    func registerInfo(id: Int, newUser: FirebaseNewUser, completion: @escaping (Result<Void, Error>) -> Void) {
+    func registerKakaoUserInfo(id: Int, newUser: FirebaseNewUser, completion: @escaping (Result<Void, Error>) -> Void) {
         memberDocRef.document("\(id)").setData([
             "id": id,
+            "name": newUser.name,
+            "position": newUser.positionType.rawValue,
+            "team": ["number": newUser.teamNumber, "type": newUser.teamType.upperCase],
+            "attendances": self.makeEmptyAttendances()
+        ]) { error in
+            guard let error = error else {
+                completion(.success(()))
+                return
+            }
+            completion(.failure(error))
+        }
+    }
+
+    func registerAppleUserInfo(id: String, newUser: FirebaseNewUser, completion: @escaping (Result<Void, Error>) -> Void) {
+        memberDocRef.document("\(id)").setData([
+            "id": Int.random(in: 1000000000..<10000000000),
             "name": newUser.name,
             "position": newUser.positionType.rawValue,
             "team": ["number": newUser.teamNumber, "type": newUser.teamType.upperCase],

--- a/attendance-ios/Source/Utilities/FirebaseWorker.swift
+++ b/attendance-ios/Source/Utilities/FirebaseWorker.swift
@@ -91,7 +91,7 @@ extension FirebaseWorker {
 // MARK: - Read
 extension FirebaseWorker {
 
-    /// 맴버 문서 id 배열을 반환합니다.
+    /// 멤버 문서 id 배열을 반환합니다.
     func getMemberDocumentIdList(completion: @escaping (Result<[String], Error>) -> Void) {
         memberDocRef.getDocuments { snapshot, error in
             if let error = error {
@@ -113,9 +113,16 @@ extension FirebaseWorker {
         }
     }
 
-    /// 문서를 반환합니다.
-    func getDocument() {
-
+    /// 멤버 문서를 반환합니다.
+    func getMemberDocument(id: String, completion: @escaping (Result<String, Error>) -> Void) {
+        let ref = memberDocRef.whereField(id, isEqualTo: "")
+        ref.getDocuments { snapshot, error in
+            if let error = error {
+                completion(.failure(error))
+            }
+            guard let document = snapshot?.documents.first else { return }
+            print("📌document: \(document)")
+        }
     }
 
 }

--- a/attendance-ios/Source/Utilities/FirebaseWorker.swift
+++ b/attendance-ios/Source/Utilities/FirebaseWorker.swift
@@ -26,7 +26,7 @@ struct FirebaseNewUser {
 
 extension FirebaseWorker {
 
-    func registerInfo(id: String, newUser: FirebaseNewUser, completion: @escaping (Result<Void, Error>) -> Void) {
+    func registerInfo(id: Int, newUser: FirebaseNewUser, completion: @escaping (Result<Void, Error>) -> Void) {
         memberDocRef.document("\(id)").setData([
             "id": id,
             "name": newUser.name,
@@ -46,7 +46,7 @@ extension FirebaseWorker {
         var attendances: [[String: Any]] = []
         let sessionCount = 20
         for id in 0..<sessionCount {
-            let empty: [String: Any] = ["sessionId": id, "attendanceType": ["text": "결석", "point": -20]]
+            let empty: [String: Any] = ["sessionId": id, "type": ["text": "결석", "point": -20]]
             attendances.append(empty)
         }
         return attendances

--- a/attendance-ios/Source/Utilities/UserDefaultsWorker.swift
+++ b/attendance-ios/Source/Utilities/UserDefaultsWorker.swift
@@ -16,7 +16,7 @@ final class UserDefaultsWorker {
 
     private let defaults = UserDefaults.standard
 
-    // MARK: - Create, Update
+    // MARK: - Set
     func set(_ value: Any?, forKey key: UserDefaultsKey) {
         defaults.set(value, forKey: key.rawValue)
     }
@@ -26,16 +26,16 @@ final class UserDefaultsWorker {
         defaults.set(value, forKey: key.rawValue)
     }
 
-    // MARK: - Read
-    func read(forKey key: UserDefaultsKey) -> Bool {
+    // MARK: - Get
+    func get(forKey key: UserDefaultsKey) -> Bool {
         defaults.bool(forKey: key.rawValue)
     }
 
-    func read(forKey key: UserDefaultsKey) -> Int {
+    func get(forKey key: UserDefaultsKey) -> Int {
         defaults.integer(forKey: key.rawValue)
     }
 
-    func read(forKey key: UserDefaultsKey) -> String? {
+    func get(forKey key: UserDefaultsKey) -> String? {
         defaults.string(forKey: key.rawValue)
     }
 
@@ -65,12 +65,20 @@ extension UserDefaultsWorker {
         return false
     }
 
+    func setKakaoTalkId(id: String) {
+        set(id, forKey: .kakaoTalkId)
+    }
+
+    func setAppleId(id: String) {
+        set(id, forKey: .appleId)
+    }
+
     func kakaoTalkId() -> String? {
-        read(forKey: .kakaoTalkId)
+        get(forKey: .kakaoTalkId)
     }
 
     func appleId() -> String? {
-        read(forKey: .appleId)
+        get(forKey: .appleId)
     }
 
     func removeKakaoTalkId() {


### PR DESCRIPTION
## 개요
- #52 회원가입, 로그인 기능 개선


## 작업 사항
### 로그인 화면
- 처음에 UserDefaults에 저장된 카카오톡 id값이 있는지 확인 
    - 있다면 바로 홈으로 이동
 
### 모델
- enum 타입의 TeamType의 rawValue값 수정

### 애플 로그인
- 애플 로그인 기능 추가
- 애플 로그인의 authorizationController 함수 BaseViewModel로 이동함
- 애플 로그인, 카카오톡 로그인시 id값 UserDefaults에 저장
- 애플 로그인으로 회원가입
    - 애플id값이 String타입이므로 문서 내의 id값을 10자리수의 랜덤한 숫자로 설정해 생성함
- 애플 로그인으로 회원가입 후 카카오톡 로그인시 처리
    - 파이어베이스에  애플id로 저장된 문서 이름, id값 변경


