### PR TITLE
#33 홈화면 오늘 세션 데이터 연동

### DIFF
--- a/attendance-ios.xcodeproj/project.pbxproj
+++ b/attendance-ios.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		5E6179AC27C670D500B1A835 /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6179AB27C670D500B1A835 /* UITextField.swift */; };
 		5E63BC9427BBD2AC0024FCE3 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5E63BC9327BBD2AC0024FCE3 /* GoogleService-Info.plist */; };
 		5E63BC9B27BBE90F0024FCE3 /* SignUpNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E63BC9A27BBE90F0024FCE3 /* SignUpNameViewController.swift */; };
+		5E68F167281197810093B985 /* UIString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E68F166281197810093B985 /* UIString.swift */; };
+		5E68F169281197FB0093B985 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E68F168281197FB0093B985 /* Date.swift */; };
 		5E6ACB3A2808648700ADF2BB /* FirebaseWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6ACB392808648700ADF2BB /* FirebaseWorker.swift */; };
 		5E6ACB3C28086A7300ADF2BB /* KakaoLoginWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6ACB3B28086A7200ADF2BB /* KakaoLoginWorker.swift */; };
 		5E6ACB41280894F800ADF2BB /* UserDefaultsWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6ACB40280894F800ADF2BB /* UserDefaultsWorker.swift */; };
@@ -100,6 +102,8 @@
 		5E6179AB27C670D500B1A835 /* UITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextField.swift; sourceTree = "<group>"; };
 		5E63BC9327BBD2AC0024FCE3 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		5E63BC9A27BBE90F0024FCE3 /* SignUpNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpNameViewController.swift; sourceTree = "<group>"; };
+		5E68F166281197810093B985 /* UIString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIString.swift; sourceTree = "<group>"; };
+		5E68F168281197FB0093B985 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		5E6ACB392808648700ADF2BB /* FirebaseWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseWorker.swift; sourceTree = "<group>"; };
 		5E6ACB3B28086A7200ADF2BB /* KakaoLoginWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginWorker.swift; sourceTree = "<group>"; };
 		5E6ACB3F2808791E00ADF2BB /* attendance-ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "attendance-ios.entitlements"; sourceTree = "<group>"; };
@@ -412,6 +416,8 @@
 				5E9CC7B927D0F57A006D8B12 /* UICollectionViewCell.swift */,
 				5EAA79D627F5ED7B00BC7397 /* UIView.swift */,
 				5EAA79D827F5EE1900BC7397 /* UIStackView.swift */,
+				5E68F166281197810093B985 /* UIString.swift */,
+				5E68F168281197FB0093B985 /* Date.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -621,6 +627,7 @@
 				527657FB27C387E40080DA32 /* UILabelWithRound.swift in Sources */,
 				52C4CDE027D0B1D1005EDE78 /* HomeBottomTabView.swift in Sources */,
 				297E957F27CFA68600452222 /* QRViewController.swift in Sources */,
+				5E68F169281197FB0093B985 /* Date.swift in Sources */,
 				527657F727C384AE0080DA32 /* UIViewController.swift in Sources */,
 				5EAA79FB27FDE42500BC7397 /* Attendance.swift in Sources */,
 				5EF69EC427A7F8B0007E9735 /* UILabel.swift in Sources */,
@@ -659,6 +666,7 @@
 				5EAA79F927FDD84C00BC7397 /* AdminMessageView.swift in Sources */,
 				5E6ACB3C28086A7300ADF2BB /* KakaoLoginWorker.swift in Sources */,
 				5E7AEF2427E21D680059FB3A /* AdminViewModel.swift in Sources */,
+				5E68F167281197810093B985 /* UIString.swift in Sources */,
 				5EAA7A0727FF24CB00BC7397 /* CollectionViewLeftAlignFlowLayout.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/attendance-ios/Source/Extensions/Date.swift
+++ b/attendance-ios/Source/Extensions/Date.swift
@@ -1,0 +1,49 @@
+//
+//  Date.swift
+//  attendance-ios
+//
+//  Created by leeesangheee on 2022/04/21.
+//
+
+import Foundation
+
+extension Date {
+
+    /// 날짜를 mm.dd 형식으로 반환합니다.
+    func mmdd() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MM.dd"
+        return dateFormatter.string(from: self)
+    }
+
+    /// 현재 날짜에서 시간, 분, 초를 없앤 날짜로 반환합니다.
+    func startDate() -> Date? {
+        guard let date = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month, .day], from: self)) else { return nil }
+        return date
+    }
+
+    /// 현재 날짜가 다른 날짜보다 과거인지를 반환합니다.
+    func isPast(than other: Date) -> Bool {
+        return self.compare(other) == .orderedDescending
+    }
+
+    /// 현재 날짜가 다른 날짜보다 과거인지를 반환합니다.
+    /// 다른 날짜가 옵셔널이면 false를 반환합니다.
+    func isPast(than other: Date?) -> Bool {
+        guard let other = other else { return false }
+        return isPast(than: other)
+    }
+
+    /// 현재 날짜가 다른 날짜보다 미래인지를 반환합니다.
+    func isFuture(than other: Date) -> Bool {
+        return self.compare(other) == .orderedAscending
+    }
+
+    /// 현재 날짜가 다른 날짜보다 미래인지를 반환합니다.
+    /// 다른 날짜가 옵셔널이면 false를 반환합니다.
+    func isFuture(than other: Date?) -> Bool {
+        guard let other = other else { return false }
+        return isFuture(than: other)
+    }
+
+}

--- a/attendance-ios/Source/Extensions/UIString.swift
+++ b/attendance-ios/Source/Extensions/UIString.swift
@@ -1,0 +1,18 @@
+//
+//  UIString.swift
+//  attendance-ios
+//
+//  Created by leeesangheee on 2022/04/21.
+//
+
+import UIKit
+
+extension String {
+
+    func date() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return dateFormatter.date(from: self)
+    }
+
+}

--- a/attendance-ios/Source/Home/HomeViewController.swift
+++ b/attendance-ios/Source/Home/HomeViewController.swift
@@ -88,14 +88,12 @@ final class HomeViewController: UIViewController {
     }()
     private let dateLabel: UILabel = {
         let label = UILabel()
-        label.text = "02.07"
         label.style(.Body1)
         label.textColor = .gray_600
         return label
     }()
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "YAPP 3번째 데브 캠프\n및 성과 공유회"
         label.style(.H1)
         label.textColor = .gray_1000
         label.numberOfLines = 0
@@ -103,7 +101,6 @@ final class HomeViewController: UIViewController {
     }()
     private let contentsLabel: UILabel = {
         let label = UILabel()
-        label.text = "드디어 마지막 성과 공유를 하는 세션입니다!\n지금까지 하나의 팀으로서 열심히 작업한 결과물을 YAPP 전원에게 보여주세요 🎉"
         label.style(.Body1)
         label.textColor = .gray_800
         label.numberOfLines = 0
@@ -237,6 +234,14 @@ final class HomeViewController: UIViewController {
             .bind(to: viewModel.input.tapSetting)
             .disposed(by: disposeBag)
 
+        viewModel.output.sessionList
+            .subscribe(onNext: { [weak self] sessionList in
+                print("sessionList: \(sessionList)")
+                DispatchQueue.main.async {
+                    self?.updateSessionInfo()
+                }
+            }).disposed(by: disposeBag)
+
         viewModel.output.goToSetting
             .observe(on: MainScheduler.instance)
             .bind(onNext: showSettingVC)
@@ -273,4 +278,21 @@ final class HomeViewController: UIViewController {
         let vc = SettingViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }
+
+    func updateSessionInfo() {
+        guard let sessionList = try? viewModel.output.sessionList.value(), let session = sessionList.todaySession() else { return }
+        dateLabel.text = session.date.date()?.mmdd() ?? ""
+        titleLabel.text = session.title
+        contentsLabel.text = session.description
+    }
+}
+
+private extension Array where Element == Session {
+
+    func todaySession() -> Session? {
+        guard let nowDate = Date().startDate() else { return nil }
+        lazy var sessions = self.filter { nowDate.isFuture(than: $0.date.date()) }
+        return sessions.first
+    }
+
 }

--- a/attendance-ios/Source/Home/HomeViewController.swift
+++ b/attendance-ios/Source/Home/HomeViewController.swift
@@ -236,7 +236,6 @@ final class HomeViewController: UIViewController {
 
         viewModel.output.sessionList
             .subscribe(onNext: { [weak self] sessionList in
-                print("sessionList: \(sessionList)")
                 DispatchQueue.main.async {
                     self?.updateSessionInfo()
                 }

--- a/attendance-ios/Source/Home/HomeViewModel.swift
+++ b/attendance-ios/Source/Home/HomeViewModel.swift
@@ -21,6 +21,7 @@ final class HomeViewModel: ViewModel {
     }
 
     struct Output {
+        let sessionList = BehaviorSubject<[Session]>(value: [])
         var goToQR = PublishRelay<Void>()
         var goToSetting = PublishRelay<Void>()
     }
@@ -28,6 +29,7 @@ final class HomeViewModel: ViewModel {
     let input = Input()
     let output = Output()
     let disposeBag = DisposeBag()
+    let configWorker = ConfigWorker()
     var homeType = BehaviorRelay<HomeType>(value: .todaySession)
     var list = [Attendance(sessionId: 1, type: AttendanceType(point: 10, text: "출석")), Attendance(sessionId: 1, type: AttendanceType(point: 10, text: "지각")),
                 Attendance(sessionId: 1, type: AttendanceType(point: 10, text: "출석 인정")), Attendance(sessionId: 1, type: AttendanceType(point: 10, text: "결석"))]
@@ -42,5 +44,12 @@ final class HomeViewModel: ViewModel {
             .subscribe(onNext: { [weak self] _ in
                 self?.output.goToSetting.accept(())
             }).disposed(by: disposeBag)
+
+        configWorker.decodeSessionList { [weak self] result in
+            switch result {
+            case .success(let list): self?.output.sessionList.onNext(list)
+            case .failure: ()
+            }
+        }
     }
 }


### PR DESCRIPTION
## 개요
- #33 홈화면 오늘 세션 데이터 연동


## 작업 사항
- 뷰모델에서 sessionList 요청 후 업데이트
- 뷰컨트롤러가 관찰 후 화면 업데이트

## 오늘 세션 판별
- 기준 날짜: 현재 날짜에서 시, 분, 초를 제외한 Date
- 세션의 날짜 정보에서 기준 날짜보다 미래인 날짜를 가진 세션을 lazy.filter함
- 가장 첫번째 세션을 반환함

## 작업 화면
<img width="250" src="https://user-images.githubusercontent.com/61302874/164477060-b0878451-0fd3-4d57-9e2a-91206cff365e.PNG">



