### PR TITLE
#77 설정 화면에서 회원 탈퇴

### DIFF
--- a/attendance-ios/Source/Setting/SettingViewController+UI.swift
+++ b/attendance-ios/Source/Setting/SettingViewController+UI.swift
@@ -77,5 +77,10 @@ extension SettingViewController {
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(51)
         }
+
+        view.addSubview(alertView)
+        alertView.snp.makeConstraints {
+            $0.top.bottom.left.right.equalToSuperview()
+        }
     }
 }

--- a/attendance-ios/Source/Setting/SettingViewController.swift
+++ b/attendance-ios/Source/Setting/SettingViewController.swift
@@ -64,6 +64,15 @@ final class SettingViewController: UIViewController {
         view.setLogout("회원탈퇴")
         return view
     }()
+    let alertView: AlertView = {
+        let view = AlertView()
+        view.isHidden = true
+        view.configureUI(text: "정말 탈퇴하시겠어요?",
+                         subText: "탈퇴하면 모든 정보가 사라져요.",
+                         leftButtonText: "취소",
+                         rightButtonText: "탈퇴합니다")
+        return view
+    }()
 
     private let viewModel = SettingViewModel()
     private var disposeBag = DisposeBag()
@@ -99,6 +108,11 @@ final class SettingViewController: UIViewController {
         viewModel.output.goToLoginVC
             .observe(on: MainScheduler.instance)
             .bind(onNext: goToLoginVC)
+            .disposed(by: disposeBag)
+
+        viewModel.output.showDialogWhenMemberOut
+            .observe(on: MainScheduler.instance)
+            .bind(onNext: showDialogWhenMemberOut)
             .disposed(by: disposeBag)
 
         viewModel.output.generation
@@ -139,6 +153,13 @@ final class SettingViewController: UIViewController {
             .bind(onNext: { [weak self] _ in
                 self?.viewModel.input.tapMemberView.accept(())
             }).disposed(by: disposeBag)
+
+        alertView.rightButton.rx.controlEvent([.touchUpInside])
+            .asObservable()
+            .subscribe(onNext: { [weak self] _ in
+                self?.viewModel.input.memberOut.accept(())
+                self?.alertView.isHidden.toggle()
+            }).disposed(by: disposeBag)
     }
 
     func showHomeVC() {
@@ -155,5 +176,10 @@ final class SettingViewController: UIViewController {
         let navC = UINavigationController(rootViewController: loginVC)
         navC.modalPresentationStyle = .fullScreen
         self.present(navC, animated: true)
+    }
+
+    // TODO: -
+    func showDialogWhenMemberOut() {
+        alertView.isHidden = false
     }
 }

--- a/attendance-ios/Source/Setting/SettingViewModel.swift
+++ b/attendance-ios/Source/Setting/SettingViewModel.swift
@@ -30,6 +30,7 @@ final class SettingViewModel: ViewModel {
     let output = Output()
     let disposeBag = DisposeBag()
     let db = Firestore.firestore()
+    let myId = BehaviorRelay<String>(value: "")
     var documentID = BehaviorRelay<String>(value: "")
     var memberData = BehaviorRelay<Member?>(value: nil)
 
@@ -57,6 +58,7 @@ final class SettingViewModel: ViewModel {
                 self?.memberOut()
             }).disposed(by: disposeBag)
 
+        checkLoginId()
         checkGeneration()
         setupName()
     }
@@ -87,4 +89,26 @@ final class SettingViewModel: ViewModel {
             self.output.goToLoginVC.accept(())
         }
     }
+
+    func checkLoginId() {
+        if let kakaoTalkId = userDefaultsWorker.kakaoTalkId(), kakaoTalkId.isEmpty == false {
+            myId.accept(kakaoTalkId)
+            getUserData()
+        } else if let appleId = userDefaultsWorker.appleId(), appleId.isEmpty == false {
+            myId.accept(appleId)
+            getUserData()
+        }
+    }
+
+    func getUserData() {
+        firebaseWorker.getMemberDocumentData(memberId: Int(myId.value) ?? 0) { result in
+            switch result {
+            case .success(let member):
+                self.memberData.accept(member)
+                self.userDefaultsWorker.setName(name: member.name)
+            case .failure: ()
+            }
+        }
+    }
+
 }

--- a/attendance-ios/Source/Setting/SettingViewModel.swift
+++ b/attendance-ios/Source/Setting/SettingViewModel.swift
@@ -93,6 +93,7 @@ final class SettingViewModel: ViewModel {
         firebaseWorker.deleteDocument(memberId: member.id) { [weak self] _ in
             guard let self = self else { return }
             self.userDefaultsWorker.removeKakaoTalkId()
+            self.userDefaultsWorker.removeAppleId()
             self.output.goToLoginVC.accept(())
         }
     }

--- a/attendance-ios/Source/Setting/SettingViewModel.swift
+++ b/attendance-ios/Source/Setting/SettingViewModel.swift
@@ -16,12 +16,14 @@ final class SettingViewModel: ViewModel {
         let tapPolicyView = PublishRelay<Void>()
         let tapLogoutView = PublishRelay<Void>()
         let tapMemberView = PublishRelay<Void>()
+        let memberOut = PublishRelay<Void>()
     }
 
     struct Output {
         var goToHome = PublishRelay<Void>()
         let goToPolicyVC = PublishRelay<Void>()
         let goToLoginVC = PublishRelay<Void>()
+        let showDialogWhenMemberOut = PublishRelay<Void>()
         var generation = BehaviorRelay<String>(value: "")
         var name = BehaviorRelay<String>(value: "")
     }
@@ -54,6 +56,11 @@ final class SettingViewModel: ViewModel {
             }).disposed(by: disposeBag)
 
         input.tapMemberView
+            .subscribe(onNext: { [weak self] _ in
+                self?.output.showDialogWhenMemberOut.accept(())
+            }).disposed(by: disposeBag)
+
+        input.memberOut
             .subscribe(onNext: { [weak self] _ in
                 self?.memberOut()
             }).disposed(by: disposeBag)

--- a/attendance-ios/Source/SignUp/SignUpNameViewController.swift
+++ b/attendance-ios/Source/SignUp/SignUpNameViewController.swift
@@ -82,7 +82,10 @@ final class SignUpNameViewController: UIViewController {
     private let alertView: AlertView = {
         let view = AlertView()
         view.isHidden = true
-        view.configureUI(text: "입력을 취소할까요?", subText: "언제든 다시 돌아올 수 있어요", leftButtonText: "아니요", rightButtonText: "취소합니다")
+        view.configureUI(text: "입력을 취소할까요?",
+                         subText: "언제든 다시 돌아올 수 있어요",
+                         leftButtonText: "아니요",
+                         rightButtonText: "취소합니다")
         return view
     }()
 

--- a/attendance-ios/Source/SignUp/SignUpPositionViewController.swift
+++ b/attendance-ios/Source/SignUp/SignUpPositionViewController.swift
@@ -56,7 +56,10 @@ final class SignUpPositionViewController: UIViewController {
     private let alertView: AlertView = {
         let view = AlertView()
         view.isHidden = true
-        view.configureUI(text: "입력을 취소할까요?", subText: "언제든 다시 돌아올 수 있어요", leftButtonText: "아니요", rightButtonText: "취소합니다")
+        view.configureUI(text: "입력을 취소할까요?",
+                         subText: "언제든 다시 돌아올 수 있어요",
+                         leftButtonText: "아니요",
+                         rightButtonText: "취소합니다")
         return view
     }()
 

--- a/attendance-ios/Source/SignUp/SignUpTeamViewController.swift
+++ b/attendance-ios/Source/SignUp/SignUpTeamViewController.swift
@@ -78,7 +78,10 @@ final class SignUpTeamViewController: UIViewController {
     private let alertView: AlertView = {
         let view = AlertView()
         view.isHidden = true
-        view.configureUI(text: "입력을 취소할까요?", subText: "언제든 다시 돌아올 수 있어요", leftButtonText: "아니요", rightButtonText: "취소합니다")
+        view.configureUI(text: "입력을 취소할까요?",
+                         subText: "언제든 다시 돌아올 수 있어요",
+                         leftButtonText: "아니요",
+                         rightButtonText: "취소합니다")
         return view
     }()
 


### PR DESCRIPTION
## 개요
- #77

## 작업 사항
- SettingsViewModel에서 member 정보 불러와 저장
- 해당 정보로 회원 탈퇴
- 회원 탈퇴 클릭시 다이얼로그 띄움
- 회원 탈퇴 성공 후 홈으로 이동

## 작업 화면
| 설정 화면 | 다이얼로그 | 탈퇴 성공 후 홈으로 이동 |
| :-: | :-: | :-: |
| <img src="https://user-images.githubusercontent.com/61302874/168720916-8527ce82-6474-41f7-b797-825c051dcbc0.PNG" > | <img src="https://user-images.githubusercontent.com/61302874/168720937-5953a67e-92d8-4177-847d-c41cac5a2f14.PNG" > | <img src="https://user-images.githubusercontent.com/61302874/168720943-3f1e777b-c4fd-45ae-94eb-a972c2cecd9b.PNG" > |

