### PR TITLE
#75 로그인

### DIFF
--- a/attendance-ios/Source/Common/BaseViewModel.swift
+++ b/attendance-ios/Source/Common/BaseViewModel.swift
@@ -52,10 +52,6 @@ final class BaseViewModel: ViewModel {
     private let userDefaultsWorker = UserDefaultsWorker()
 
     init() {
-        // TODO: - 테스트를 위해 추가, 이후 삭제
-        logoutWithKakao()
-        //
-
         checkLoginId()
 
         subscribeInput()
@@ -128,10 +124,6 @@ private extension BaseViewModel {
             case .failure: ()
             }
         }
-    }
-
-    func checkIsRegisteredUser(id: String) {
-
     }
 
     func logoutWithKakao() {

--- a/attendance-ios/Source/Common/BaseViewModel.swift
+++ b/attendance-ios/Source/Common/BaseViewModel.swift
@@ -69,20 +69,25 @@ final class BaseViewModel: ViewModel {
 // MARK: - Check
 private extension BaseViewModel {
 
-    func checkLoginId() {
-        checkKakaoId()
-        checkAppleId()
+    @discardableResult
+    func checkLoginId() -> Bool {
+        guard checkKakaoId() == false, checkAppleId() == false else { return true }
+        return false
     }
 
-    func checkKakaoId() {
-        guard let kakaoTalkId = userDefaultsWorker.kakaoTalkId(), kakaoTalkId.isEmpty == false else { return }
+    @discardableResult
+    func checkKakaoId() -> Bool {
+        guard let kakaoTalkId = userDefaultsWorker.kakaoTalkId(), kakaoTalkId.isEmpty == false else { return false }
         output.kakaoTalkId.onNext(kakaoTalkId)
         output.goToHome.accept(())
+        return true
     }
 
-    func checkAppleId() {
-        guard let appleId = userDefaultsWorker.appleId(), appleId.isEmpty == false else { return }
+    @discardableResult
+    func checkAppleId() -> Bool {
+        guard let appleId = userDefaultsWorker.appleId(), appleId.isEmpty == false else { return false }
         output.appleId.onNext(appleId)
+        return true
     }
 
 }
@@ -142,16 +147,12 @@ private extension BaseViewModel {
 extension BaseViewModel {
 
     func authorizationController(authorization: ASAuthorization) {
-        print("authorizationController")
-
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
 //            let userIdentifier = appleIDCredential.user
 //            let fullName = appleIDCredential.fullName
 //            let email = appleIDCredential.email
-
-            checkKakaoId()
-            checkAppleId()
+            guard checkLoginId() == false else { return }
             signUpWithApple()
         default: break
         }

--- a/attendance-ios/Source/Common/BaseViewModel.swift
+++ b/attendance-ios/Source/Common/BaseViewModel.swift
@@ -70,16 +70,21 @@ final class BaseViewModel: ViewModel {
 private extension BaseViewModel {
 
     func checkLoginId() {
-        if let kakaoTalkId = userDefaultsWorker.kakaoTalkId(), kakaoTalkId.isEmpty == false {
-            output.kakaoTalkId.onNext(kakaoTalkId)
-            output.goToHome.accept(())
-            return
-        } else if let appleId = userDefaultsWorker.appleId(), appleId.isEmpty == false {
-            output.appleId.onNext(appleId)
-        } else {
-            // MARK: - UserDefaults에 저장된 id가 없음
-            output.goToSignUp.accept(())
-        }
+        checkKakaoId()
+        checkAppleId()
+    }
+
+    func checkKakaoId() {
+        guard let kakaoTalkId = userDefaultsWorker.kakaoTalkId(), kakaoTalkId.isEmpty == false else { return }
+        output.kakaoTalkId.onNext(kakaoTalkId)
+        print("저장된 kakaoTalkId: \(kakaoTalkId)")
+        output.goToHome.accept(())
+    }
+
+    func checkAppleId() {
+        guard let appleId = userDefaultsWorker.appleId(), appleId.isEmpty == false else { return }
+        print("저장된 appleId: \(appleId)")
+        output.appleId.onNext(appleId)
     }
 
 }

--- a/attendance-ios/Source/Setting/SettingViewModel.swift
+++ b/attendance-ios/Source/Setting/SettingViewModel.swift
@@ -74,7 +74,6 @@ final class SettingViewModel: ViewModel {
     }
 
     func logout() {
-        userDefaultsWorker.removeKakaoTalkId()
         output.goToLoginVC.accept(())
     }
 

--- a/attendance-ios/Source/SignUp/SignUpViewModel.swift
+++ b/attendance-ios/Source/SignUp/SignUpViewModel.swift
@@ -115,22 +115,29 @@ extension SignUpViewModel {
 
         let newUser = FirebaseNewMember(name: name, positionType: positionType, teamType: teamType, teamNumber: teamNumber)
 
-        if kakaoTalkId.isEmpty == false {
-            guard let id = Int(kakaoTalkId) else { return }
-            firebaseWorker.registerKakaoUserInfo(id: id, newUser: newUser) { [weak self] result in
-                switch result {
-                case .success: self?.output.goToHome.accept(())
-                case .failure: ()
-                }
-            }
+        if kakaoTalkId.isEmpty == false, let id = Int(kakaoTalkId) {
+            registerKakaoUserInfo(id: id, newUser: newUser)
         } else if appleId.isEmpty == false {
-            firebaseWorker.registerAppleUserInfo(id: appleId, newUser: newUser) { [weak self] result in
-                switch result {
-                case .success:
-                    self?.userDefaultsWorker.setAppleId(id: appleId)
-                    self?.output.goToHome.accept(())
-                case .failure: ()
-                }
+            registerWithApple(id: appleId, newUser: newUser)
+        }
+    }
+
+    func registerKakaoUserInfo(id: Int, newUser: FirebaseNewMember) {
+        firebaseWorker.registerKakaoUserInfo(id: id, newUser: newUser) { [weak self] result in
+            switch result {
+            case .success: self?.output.goToHome.accept(())
+            case .failure: ()
+            }
+        }
+    }
+
+    func registerWithApple(id: String, newUser: FirebaseNewMember) {
+        firebaseWorker.registerAppleUserInfo(id: id, newUser: newUser) { [weak self] result in
+            switch result {
+            case .success:
+                self?.userDefaultsWorker.setAppleId(id: id)
+                self?.output.goToHome.accept(())
+            case .failure: ()
             }
         }
     }


### PR DESCRIPTION
## 개요
- #75

## 작업 사항
- 애플 회원가입 -> 카카오톡 로그인시 회원가입 화면으로 넘어가는 문제 해결
- 애플 회원가입 -> 이후 카카오톡 로그인시 문서 변경 안되는 문제 해결
- 애플 로그인으로 회원가입시 문서 이름을 애플 id가 아닌, 문서 내 맴버 id와 동일하게 랜덤한 숫자로 설정
- 애플 회원가입 후 카카오톡 로그인시 UserDefaults에 저장된 애플 id값 제거