### PR TITLE
#103 로그인 - 이스터에그 뷰 수정

### DIFF
--- a/attendance-ios/Source/Common/BaseViewModel.swift
+++ b/attendance-ios/Source/Common/BaseViewModel.swift
@@ -43,7 +43,7 @@ final class BaseViewModel: ViewModel {
 
         let yappConfig = BehaviorSubject<YappConfig?>(value: nil)
         let easterEggCount = BehaviorSubject<Int>(value: 0)
-        let isEasterEggKeyValid = BehaviorSubject<Bool>(value: false)
+        let isEasterEggKeyValid = BehaviorSubject<Bool?>(value: nil)
 
         let goToSignUp = PublishRelay<Void>()
         let goToHome = PublishRelay<Void>()
@@ -218,7 +218,6 @@ private extension BaseViewModel {
         output.showEasterEgg.accept(())
     }
 
-    // TODO: -
     func checkEasterEggKey() {
         guard let key = try? input.easterEggKey.value(),
               let adminPassword = try? output.yappConfig.value()?.adminPassword else { return }

--- a/attendance-ios/Source/Login/EasterEggView.swift
+++ b/attendance-ios/Source/Login/EasterEggView.swift
@@ -20,10 +20,11 @@ final class EasterEggView: UIView {
 
         static let textFieldHeight: CGFloat = 47
         static let textFieldFontSize: CGFloat = 16
+        static let wrongLabelHeight: CGFloat = 20
         static let buttonHeight: CGFloat = 47
         static let buttonSpacing: CGFloat = 12
 
-        static let containerViewHeight: CGFloat = Constants.labelStackViewHeight+textFieldHeight+Constants.buttonHeight+Constants.padding+Constants.spacing*3
+        static let containerViewHeight: CGFloat = Constants.labelStackViewHeight+textFieldHeight+Constants.wrongLabelHeight+Constants.buttonHeight+Constants.padding+Constants.spacing*4
     }
 
     private let containerView: UIView = {
@@ -69,6 +70,14 @@ final class EasterEggView: UIView {
         textField.textAlignment = .center
         textField.isSecureTextEntry = true
         return textField
+    }()
+
+    private let wrongLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .etc_red
+        label.font = .Pretendard(type: .semiBold, size: 16)
+        label.text = "틀린 비밀번호입니다"
+        return label
     }()
 
     private let stackView: UIStackView = {
@@ -149,7 +158,7 @@ private extension EasterEggView {
 
     func configureLayout() {
         addSubview(containerView)
-        containerView.addSubviews([labelStackView, textField, stackView])
+        containerView.addSubviews([labelStackView, textField, wrongLabel, stackView])
         stackView.addArrangedSubviews([leftButton, rightButton])
         labelStackView.addArrangedSubviews([label, subLabel])
 
@@ -164,12 +173,17 @@ private extension EasterEggView {
             $0.height.equalTo(Constants.labelStackViewHeight)
         }
         textField.snp.makeConstraints {
-            $0.top.equalTo(labelStackView.snp.bottom).offset(Constants.padding)
+            $0.top.equalTo(labelStackView.snp.bottom).offset(Constants.spacing)
             $0.left.right.equalToSuperview().inset(Constants.padding)
             $0.height.equalTo(Constants.textFieldHeight)
         }
+        wrongLabel.snp.makeConstraints {
+            $0.top.equalTo(textField.snp.bottom).offset(Constants.spacing)
+            $0.left.right.equalToSuperview().inset(Constants.padding)
+            $0.height.equalTo(Constants.wrongLabelHeight)
+        }
         stackView.snp.makeConstraints {
-            $0.top.equalTo(textField.snp.bottom).offset(Constants.padding)
+            $0.top.equalTo(wrongLabel.snp.bottom).offset(Constants.spacing)
             $0.bottom.equalToSuperview().offset(Constants.spacing)
             $0.left.right.bottom.equalToSuperview().inset(Constants.padding)
             $0.height.equalTo(Constants.buttonHeight)

--- a/attendance-ios/Source/Login/EasterEggView.swift
+++ b/attendance-ios/Source/Login/EasterEggView.swift
@@ -20,11 +20,12 @@ final class EasterEggView: UIView {
 
         static let textFieldHeight: CGFloat = 47
         static let textFieldFontSize: CGFloat = 16
-        static let wrongLabelHeight: CGFloat = 20
+        static let wrongMessageLabelHeight: CGFloat = 20
         static let buttonHeight: CGFloat = 47
         static let buttonSpacing: CGFloat = 12
 
-        static let containerViewHeight: CGFloat = Constants.labelStackViewHeight+textFieldHeight+Constants.wrongLabelHeight+Constants.buttonHeight+Constants.padding+Constants.spacing*4
+        static let containerViewHeight: CGFloat = Constants.labelStackViewHeight+textFieldHeight+Constants.buttonHeight+Constants.padding+Constants.spacing*3
+        static let containerViewHeightWithMessage: CGFloat = Constants.labelStackViewHeight+textFieldHeight+Constants.wrongMessageLabelHeight+Constants.buttonHeight+Constants.padding+Constants.spacing*4
     }
 
     private let containerView: UIView = {
@@ -72,11 +73,12 @@ final class EasterEggView: UIView {
         return textField
     }()
 
-    private let wrongLabel: UILabel = {
+    private let wrongMessageLabel: UILabel = {
         let label = UILabel()
         label.textColor = .etc_red
         label.font = .Pretendard(type: .semiBold, size: 16)
         label.text = "틀린 비밀번호입니다"
+        label.isHidden = true
         return label
     }()
 
@@ -141,6 +143,28 @@ extension EasterEggView {
 
 }
 
+// MARK: - Error Message
+extension EasterEggView {
+
+    func showWrongMessage() {
+        let height = Constants.containerViewHeightWithMessage
+        containerView.snp.updateConstraints {
+            $0.height.equalTo(height)
+        }
+        wrongMessageLabel.isHidden = false
+    }
+
+    func hideWrongMessage() {
+        let height = Constants.containerViewHeight
+        containerView.snp.updateConstraints {
+            $0.height.equalTo(height)
+        }
+        wrongMessageLabel.isHidden = true
+    }
+
+}
+
+// MARK: - UI
 private extension EasterEggView {
 
     func bindSubViews() {
@@ -158,7 +182,7 @@ private extension EasterEggView {
 
     func configureLayout() {
         addSubview(containerView)
-        containerView.addSubviews([labelStackView, textField, wrongLabel, stackView])
+        containerView.addSubviews([labelStackView, textField, wrongMessageLabel, stackView])
         stackView.addArrangedSubviews([leftButton, rightButton])
         labelStackView.addArrangedSubviews([label, subLabel])
 
@@ -177,13 +201,12 @@ private extension EasterEggView {
             $0.left.right.equalToSuperview().inset(Constants.padding)
             $0.height.equalTo(Constants.textFieldHeight)
         }
-        wrongLabel.snp.makeConstraints {
+        wrongMessageLabel.snp.makeConstraints {
             $0.top.equalTo(textField.snp.bottom).offset(Constants.spacing)
             $0.left.right.equalToSuperview().inset(Constants.padding)
-            $0.height.equalTo(Constants.wrongLabelHeight)
+            $0.height.equalTo(Constants.wrongMessageLabelHeight)
         }
         stackView.snp.makeConstraints {
-            $0.top.equalTo(wrongLabel.snp.bottom).offset(Constants.spacing)
             $0.bottom.equalToSuperview().offset(Constants.spacing)
             $0.left.right.bottom.equalToSuperview().inset(Constants.padding)
             $0.height.equalTo(Constants.buttonHeight)

--- a/attendance-ios/Source/Login/EasterEggView.swift
+++ b/attendance-ios/Source/Login/EasterEggView.swift
@@ -67,6 +67,7 @@ final class EasterEggView: UIView {
         textField.textColor = .gray_800
         textField.tintColor = .yapp_orange
         textField.textAlignment = .center
+        textField.isSecureTextEntry = true
         return textField
     }()
 

--- a/attendance-ios/Source/Login/LoginViewController.swift
+++ b/attendance-ios/Source/Login/LoginViewController.swift
@@ -168,6 +168,7 @@ private extension LoginViewController {
             .subscribe(onNext: { [weak self] text in
                 guard let text = text else { return }
                 self?.viewModel.input.easterEggKey.onNext(text)
+                self?.easterEggView.hideWrongMessage()
             }).disposed(by: disposeBag)
     }
 

--- a/attendance-ios/Source/Login/LoginViewController.swift
+++ b/attendance-ios/Source/Login/LoginViewController.swift
@@ -134,9 +134,12 @@ private extension LoginViewController {
         viewModel.output.isEasterEggKeyValid
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] isValid in
+                guard let isValid = isValid else { return }
                 self?.clearTextField()
                 if isValid == true {
                     self?.easterEggView.isHidden = true
+                } else {
+                    self?.easterEggView.showWrongMessage()
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 이슈
- #103 

## 작업 사항
- 이스터에그 텍스트 ***로 표시
- 키가 유효하지 않은 경우에 "틀린 ~" 표시
- 틀린 메세지가 표시된 후 다시 입력하면 메세지 표시 안함

## 작업 화면
* 애플 기기에서 화면 캡쳐시에는 텍스트필드 텍스트가 보이지 않습니다

| 이스터 에그  | 입력중 | 유효하지 않은 경우 |
| :-:  | :-: | :-: |
| <img width="200" src="https://user-images.githubusercontent.com/61302874/169024400-b39d4665-fd2f-4549-b340-496e10286333.PNG" > | <img width="200" src="https://user-images.githubusercontent.com/61302874/169024151-7239ee97-5d63-49f1-be2f-2cb4fef7c90a.PNG" > | <img width="200" src="https://user-images.githubusercontent.com/61302874/169024166-c93400b0-b1c5-4a9c-a820-507439b2ce3e.PNG" > |


