### PR TITLE
#94 로그인 - 로딩 화면 추가

### DIFF
--- a/attendance-ios/Source/Extensions/UIKit/UIViewController.swift
+++ b/attendance-ios/Source/Extensions/UIKit/UIViewController.swift
@@ -54,3 +54,52 @@ extension UIViewController {
     @objc func navigationBackButtonTapped() { }
 
 }
+
+// MARK: - Loading View
+extension UIViewController {
+
+    static var loadingView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white.withAlphaComponent(0.6)
+
+        let dotDiameter: CGFloat = 10
+        let spacing: CGFloat = 8
+        let dotStackView: UIStackView = {
+            let stackView = UIStackView()
+            stackView.axis = .horizontal
+            stackView.spacing = spacing
+            return stackView
+        }()
+        (1...3).forEach { _ in
+            let dot = UIView()
+            dot.snp.makeConstraints {
+                $0.width.height.equalTo(dotDiameter)
+            }
+            dot.layer.cornerRadius = dotDiameter/2
+            dot.backgroundColor = .yapp_orange
+            dotStackView.addArrangedSubview(dot)
+        }
+        view.addSubview(dotStackView)
+        dotStackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(dotDiameter*3+spacing*2)
+            $0.height.equalTo(dotDiameter)
+        }
+
+        return view
+    }()
+
+    func showLoadingView() {
+        let loadingView = UIViewController.loadingView
+        view.addSubview(loadingView)
+        loadingView.snp.makeConstraints {
+            $0.top.bottom.left.right.equalToSuperview()
+        }
+    }
+
+    func hideLoadingView() {
+        let loadingView = UIViewController.loadingView
+        loadingView.removeFromSuperview()
+    }
+
+}

--- a/attendance-ios/Source/Login/LoginViewController.swift
+++ b/attendance-ios/Source/Login/LoginViewController.swift
@@ -148,6 +148,13 @@ private extension LoginViewController {
             .observe(on: MainScheduler.instance)
             .bind(onNext: showToastWhenFailedToLogin)
             .disposed(by: disposeBag)
+
+        viewModel.output.isLoading
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] isLoading in
+                isLoading ? self?.showLoadingView() : self?.hideLoadingView()
+            })
+            .disposed(by: disposeBag)
     }
 
     func bindSubviews() {
@@ -218,12 +225,13 @@ private extension LoginViewController {
 // MARK: - Apple Login
 extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
 
-    func setupAppleLogin() {
+    private func setupAppleLogin() {
         authorizationController.delegate = self
         authorizationController.presentationContextProvider = self
     }
 
-    func loginWithApple() {
+    private func loginWithApple() {
+        viewModel.input.tapAppleLogin.accept(())
         authorizationController.performRequests()
     }
 


### PR DESCRIPTION
## 이슈
- #94

## 작업 사항
- UIViewController의 extension으로 로딩 화면 추가/제거
- 로딩 화면을 UIViewController의 연산 프로퍼티로 작성해 활용
- BaseViewModel의 isLoading값을 관찰, true일 때 로딩화면 띄움

## 작업 화면
| 카카오톡 로그인 | 애플 로그인 |
| :-: | :-: |
| <img width="200" src="https://user-images.githubusercontent.com/61302874/169082302-6a11cdb4-4a6e-4d5c-9e32-07d2c281db52.gif" > | <img width="200" src="https://user-images.githubusercontent.com/61302874/169082353-ea8ef0c3-3eaa-4263-8314-ceaca988fe23.gif" > |

