### PR TITLE
로그인 - 키보드가 이스터 에그창을 가릴 경우 처리

### DIFF
--- a/attendance-ios/Source/Login/EasterEggView.swift
+++ b/attendance-ios/Source/Login/EasterEggView.swift
@@ -205,6 +205,7 @@ private extension EasterEggView {
             .asObservable()
             .subscribe(onNext: { [weak self] _ in
                 self?.endEditingTextField()
+                self?.hideWrongMessage()
                 self?.isHidden = true
             }).disposed(by: disposeBag)
     }

--- a/attendance-ios/Source/Login/EasterEggView.swift
+++ b/attendance-ios/Source/Login/EasterEggView.swift
@@ -21,6 +21,7 @@ final class EasterEggView: UIView {
         static let textFieldHeight: CGFloat = 47
         static let textFieldFontSize: CGFloat = 16
         static let wrongMessageLabelHeight: CGFloat = 20
+        static let keyboardPadding: CGFloat = 40
         static let buttonHeight: CGFloat = 47
         static let buttonSpacing: CGFloat = 12
 
@@ -139,6 +140,29 @@ extension EasterEggView {
 
     func hideKeyboard() {
         textField.endEditing(true)
+    }
+
+}
+
+// MARK: - Keyboard
+extension EasterEggView {
+
+    func animateWhenKeyboardShow(with keyboardHeight: CGFloat) {
+        let viewHeight = bounds.height
+        let containerHeight = containerView.bounds.height
+        let padding = Constants.keyboardPadding
+        let offset = viewHeight/2-(keyboardHeight+containerHeight/2+padding)
+        guard offset < 0 else { return }
+
+        containerView.snp.updateConstraints {
+            $0.centerY.equalToSuperview().offset(offset)
+        }
+    }
+
+    func animateWhenKeyboardHide() {
+        containerView.snp.updateConstraints {
+            $0.centerY.equalToSuperview().offset(0)
+        }
     }
 
 }

--- a/attendance-ios/Source/Login/EasterEggView.swift
+++ b/attendance-ios/Source/Login/EasterEggView.swift
@@ -154,15 +154,24 @@ extension EasterEggView {
         let offset = viewHeight/2-(keyboardHeight+containerHeight/2+padding)
         guard offset < 0 else { return }
 
-        containerView.snp.updateConstraints {
-            $0.centerY.equalToSuperview().offset(offset)
-        }
+        UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseInOut, animations: { [weak self] in
+            self?.containerView.snp.updateConstraints {
+                $0.centerY.equalToSuperview().offset(offset)
+            }
+            self?.containerView.superview?.layoutIfNeeded()
+        })
     }
 
     func animateWhenKeyboardHide() {
         containerView.snp.updateConstraints {
             $0.centerY.equalToSuperview().offset(0)
         }
+        UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseInOut, animations: { [weak self] in
+            self?.containerView.snp.updateConstraints {
+                $0.centerY.equalToSuperview().offset(0)
+            }
+            self?.containerView.superview?.layoutIfNeeded()
+        })
     }
 
 }

--- a/attendance-ios/Source/Login/LoginViewController.swift
+++ b/attendance-ios/Source/Login/LoginViewController.swift
@@ -337,22 +337,8 @@ private extension LoginViewController {
     }
 
     func configureLayout() {
-        view.addSubviews([titleLabel, appleLoginButton, kakaoLoginButton, secretAdminButton, easterEggView])
-        view.addSubviews([mainSplashView, splashBackgroundView, loginSplashView])
-
-        loginSplashView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(40)
-            $0.bottom.equalToSuperview().inset(80)
-            $0.left.right.equalToSuperview().inset(10)
-        }
-        splashBackgroundView.snp.makeConstraints {
-            $0.top.bottom.left.right.equalToSuperview()
-        }
-        mainSplashView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(40)
-            $0.left.right.equalToSuperview().inset(68)
-            $0.height.equalTo(view.bounds.width)
-        }
+        view.addSubviews([titleLabel, appleLoginButton, kakaoLoginButton])
+        view.addSubviews([loginSplashView, splashBackgroundView, mainSplashView, secretAdminButton, easterEggView])
 
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(mainSplashView.snp.bottom)
@@ -367,6 +353,20 @@ private extension LoginViewController {
             $0.top.equalTo(appleLoginButton.snp.bottom).offset(Constants.buttonSpacing)
             $0.left.right.equalToSuperview().inset(Constants.padding)
             $0.height.equalTo(Constants.buttonHeight)
+        }
+
+        loginSplashView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(40)
+            $0.bottom.equalToSuperview().inset(80)
+            $0.left.right.equalToSuperview().inset(10)
+        }
+        splashBackgroundView.snp.makeConstraints {
+            $0.top.bottom.left.right.equalToSuperview()
+        }
+        mainSplashView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(40)
+            $0.left.right.equalToSuperview().inset(68)
+            $0.height.equalTo(view.bounds.width)
         }
         secretAdminButton.snp.makeConstraints {
             $0.center.equalTo(mainSplashView)

--- a/attendance-ios/Source/Login/LoginViewController.swift
+++ b/attendance-ios/Source/Login/LoginViewController.swift
@@ -105,6 +105,7 @@ final class LoginViewController: UIViewController {
 
         setupAppleLogin()
         setupDelegate()
+        setKeyboardObserver()
 
         setupLoginSplashView()
         setupMainSplashView()
@@ -300,6 +301,22 @@ extension LoginViewController {
 
     func clearTextField() {
         easterEggView.clearTextField()
+    }
+
+    func setKeyboardObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    @objc func keyboardWillShow(notification: NSNotification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardHeight = keyboardFrame.cgRectValue.height
+            easterEggView.animateWhenKeyboardShow(with: keyboardHeight)
+        }
+    }
+
+    @objc func keyboardWillHide(notification: NSNotification) {
+        easterEggView.animateWhenKeyboardHide()
     }
 
 }


### PR DESCRIPTION
## 이슈
- #114 

## 작업 사항
- 키보드 올라오고 내려올 때 감지
- 키보드가 이스터 에그창을 가릴 경우에만 뷰 위치 업데이트
- 뷰 위치 업데이트시 애니메이션

## 작업 화면
*정책상 키보드와 텍스트필드는 영상에 보이지 않습니다
 <img width="200" src="https://user-images.githubusercontent.com/61302874/169455389-9611f47e-d558-468d-a10c-c4f567fc9e36.gif" >

