### PR TITLE
#95 개인정보처리방침 Loading 추가, #32 QR 데이터 연동 완료

### DIFF
--- a/attendance-ios/Source/Extensions/UIKit/UIViewController.swift
+++ b/attendance-ios/Source/Extensions/UIKit/UIViewController.swift
@@ -40,6 +40,7 @@ extension UIViewController {
         let backButton: UIButton = {
             let button = UIButton()
             button.setImage(UIImage(named: "back"), for: .normal)
+			button.contentEdgeInsets = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
             return button
         }()
         view.addSubview(backButton)

--- a/attendance-ios/Source/Home/HomeTotalScoreTableViewCell.swift
+++ b/attendance-ios/Source/Home/HomeTotalScoreTableViewCell.swift
@@ -84,7 +84,7 @@ final class HomeTotalScoreTableViewCell: BaseTableViewCell {
         helpButton.snp.makeConstraints {
             $0.top.equalToSuperview().offset(40)
             $0.trailing.equalToSuperview().offset(-26)
-            $0.width.height.equalTo(40)
+            $0.width.height.equalTo(44)
         }
         stackView.addArrangedSubview(containerView)
         containerView.snp.makeConstraints {

--- a/attendance-ios/Source/Home/HomeViewModel.swift
+++ b/attendance-ios/Source/Home/HomeViewModel.swift
@@ -46,6 +46,7 @@ final class HomeViewModel: ViewModel {
     let homeType = BehaviorRelay<HomeType>(value: .todaySession)
     let myId = BehaviorRelay<String>(value: "")
     let memberData = BehaviorRelay<Member?>(value: nil)
+	let currentType = BehaviorRelay<AttendanceType>(value: .attendance)
 
     private let userDefaultsWorker = UserDefaultsWorker()
     private let firebaseWorker = FirebaseWorker()

--- a/attendance-ios/Source/QR/QRViewController.swift
+++ b/attendance-ios/Source/QR/QRViewController.swift
@@ -45,8 +45,9 @@ final class QRViewController: UIViewController {
 	}()
 
 	private let captureSession = AVCaptureSession()
+	var updateHomeData : ((Bool) -> Void)?
 
-	private let viewModel = QRViewModel()
+	var viewModel = QRViewModel()
 	private var disposeBag = DisposeBag()
 
     override func viewWillAppear(_ animated: Bool) {
@@ -119,12 +120,16 @@ final class QRViewController: UIViewController {
     }
 
 	func showCheck() {
+		viewModel.updateAttendances()
         UIView.animate(withDuration: 3.0, delay: 0.1, options: .curveEaseOut, animations: {
+			self.showToast(message: "출석 완료")
             self.checkView.isHidden = false
+			if let updateHomeData = self.updateHomeData {
+				updateHomeData(true)
+			}
 		}, completion: { _ in
-            UIView.animate(withDuration: 3.0, delay: 3.0, options: .curveEaseOut, animations: {
-//                self.showHomeVC()
-				self.showToast(message: "출석 완료")
+            UIView.animate(withDuration: 3.0, delay: 2.0, options: .curveEaseOut, animations: {
+				self.showHomeVC()
             }, completion: nil)
         })
 	}

--- a/attendance-ios/Source/QR/QRViewModel.swift
+++ b/attendance-ios/Source/QR/QRViewModel.swift
@@ -19,12 +19,15 @@ final class QRViewModel: ViewModel {
         let time = BehaviorSubject<String>(value: "")
         let showToastFail = PublishRelay<Void>()
 		let sessionList = BehaviorRelay<[Session]>(value: [])
+		let memberData = BehaviorSubject<Member?>(value: nil)
+		let currentType = BehaviorRelay<AttendanceType>(value: .attendance)
 	}
 
 	let input = Input()
 	let output = Output()
 	let disposeBag = DisposeBag()
     private let configWorker = ConfigWorker()
+	private let firebaseWorker = FirebaseWorker()
 
 	init() {
 		input.tapClose
@@ -53,4 +56,11 @@ final class QRViewModel: ViewModel {
             }
         }
     }
+
+	func updateAttendances() {
+		guard let member = try? output.memberData.value(), let session = output.sessionList.value.todaySession() else { return }
+		var attendances = member.attendances
+		attendances[session.sessionId].type = AttendanceData(point: output.currentType.value.point, text: output.currentType.value.text)
+		firebaseWorker.updateMemberAttendances(memberId: member.id, attendances: attendances)
+	}
 }

--- a/attendance-ios/Source/Setting/SettingPrivacyPolicyViewController.swift
+++ b/attendance-ios/Source/Setting/SettingPrivacyPolicyViewController.swift
@@ -54,17 +54,39 @@ final class SettingPrivacyPolicyViewController: UIViewController {
     }
 
     func bind() {
+		wkWebView.navigationDelegate = self
         navigationBarView.backButton.rx.tap
             .bind(to: viewModel.input.tapBack)
             .disposed(by: disposeBag)
 
         viewModel.output.goToHome
             .observe(on: MainScheduler.instance)
-            .bind(onNext: showHomeVC)
+            .bind(onNext: showSettingVC)
             .disposed(by: disposeBag)
+
+		viewModel.output.isLoading
+			.observe(on: MainScheduler.instance)
+			.subscribe(onNext: { [weak self] isLoading in
+				isLoading ? self?.showLoadingView() : self?.hideLoadingView()
+			})
+			.disposed(by: disposeBag)
     }
 
-    func showHomeVC() {
+    func showSettingVC() {
         self.navigationController?.popViewController(animated: true)
     }
+}
+
+extension SettingPrivacyPolicyViewController: WKNavigationDelegate {
+	func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+		viewModel.output.isLoading.onNext(true)
+	}
+
+	func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+		viewModel.output.isLoading.onNext(false)
+	}
+
+	func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+		showSettingVC()
+	}
 }

--- a/attendance-ios/Source/Setting/SettingViewModel.swift
+++ b/attendance-ios/Source/Setting/SettingViewModel.swift
@@ -27,6 +27,7 @@ final class SettingViewModel: ViewModel {
         let showToastWhenError = PublishRelay<Void>()
         var generation = BehaviorRelay<String>(value: "")
         var name = BehaviorRelay<String>(value: "")
+		let isLoading = BehaviorSubject<Bool>(value: false)
     }
 
     let input = Input()

--- a/attendance-ios/Source/SignUp/SignUpPositionViewController.swift
+++ b/attendance-ios/Source/SignUp/SignUpPositionViewController.swift
@@ -173,8 +173,7 @@ private extension SignUpPositionViewController {
 
     func goToHome() {
         let homeVC = HomeViewController()
-        homeVC.modalPresentationStyle = .fullScreen
-        self.present(homeVC, animated: true, completion: nil)
+		navigationController?.pushViewController(homeVC, animated: true)
     }
 
     func goToLogin() {

--- a/attendance-ios/Source/SignUp/SignUpTeamViewController.swift
+++ b/attendance-ios/Source/SignUp/SignUpTeamViewController.swift
@@ -174,8 +174,15 @@ private extension SignUpTeamViewController {
             .subscribe(onNext: { [weak self] _ in
                 self?.goToHome()
             })
-            .disposed(by: disposeBag)
-    }
+			.disposed(by: disposeBag)
+
+		viewModel.output.goToLoginVC
+			.observe(on: MainScheduler.instance)
+			.subscribe(onNext: { [weak self] _ in
+				self?.goToLogin()
+			})
+			.disposed(by: disposeBag)
+	}
 
     func bindButton() {
         okButton.rx.controlEvent([.touchUpInside])

--- a/attendance-ios/Source/SignUp/SignUpTeamViewController.swift
+++ b/attendance-ios/Source/SignUp/SignUpTeamViewController.swift
@@ -285,8 +285,7 @@ private extension SignUpTeamViewController {
 
     func goToHome() {
         let homeVC = HomeViewController()
-        homeVC.modalPresentationStyle = .fullScreen
-        self.present(homeVC, animated: true, completion: nil)
+		navigationController?.pushViewController(homeVC, animated: true)
     }
 
     func goToLogin() {

--- a/attendance-ios/Source/SignUp/SignUpViewModel.swift
+++ b/attendance-ios/Source/SignUp/SignUpViewModel.swift
@@ -34,6 +34,7 @@ final class SignUpViewModel: ViewModel {
 
         let complete = PublishRelay<Void>()
         let goToHome = PublishRelay<Void>()
+		let goToLoginVC = PublishRelay<Void>()
     }
 
     let input = Input()
@@ -128,7 +129,7 @@ extension SignUpViewModel {
         firebaseWorker.registerKakaoUserInfo(id: id, newUser: newUser) { [weak self] result in
             switch result {
             case .success: self?.output.goToHome.accept(())
-            case .failure: ()
+            case .failure: self?.output.goToLoginVC.accept(())
             }
         }
     }
@@ -136,9 +137,8 @@ extension SignUpViewModel {
     func registerWithApple(id: String, newUser: FirebaseNewMember) {
         firebaseWorker.registerAppleUserInfo(id: id, newUser: newUser) { [weak self] result in
             switch result {
-            case .success:
-                self?.output.goToHome.accept(())
-            case .failure: ()
+            case .success: self?.output.goToHome.accept(())
+            case .failure: self?.output.goToLoginVC.accept(())
             }
         }
     }

--- a/attendance-ios/Source/SignUp/SignUpViewModel.swift
+++ b/attendance-ios/Source/SignUp/SignUpViewModel.swift
@@ -116,8 +116,10 @@ extension SignUpViewModel {
         let newUser = FirebaseNewMember(name: name, positionType: positionType, teamType: teamType, teamNumber: teamNumber)
 
         if kakaoTalkId.isEmpty == false, let id = Int(kakaoTalkId) {
+			userDefaultsWorker.setKakaoTalkId(id: kakaoTalkId)
             registerKakaoUserInfo(id: id, newUser: newUser)
         } else if appleId.isEmpty == false {
+			userDefaultsWorker.setAppleId(id: appleId)
             registerWithApple(id: appleId, newUser: newUser)
         }
     }
@@ -135,7 +137,6 @@ extension SignUpViewModel {
         firebaseWorker.registerAppleUserInfo(id: id, newUser: newUser) { [weak self] result in
             switch result {
             case .success:
-                self?.userDefaultsWorker.setAppleId(id: id)
                 self?.output.goToHome.accept(())
             case .failure: ()
             }


### PR DESCRIPTION
- home 이동시 present 대신 push
- 카카오회원가입시 userdefault에 아이디 저장하기 추가
- 회원가입시 파이어스토어DB 저장 실패시 처음으로 이동되게 수정
- 뒤로가기 버튼 터치영역 넓게 수정
- 개인정보처리방침 Loading 추가
- QR 데이터 연동 완료