### PR TITLE
#182 애플 회원가입 -> 카카오 로그인 -> 애플 로그인시 홈으로 이동되지 않는 문제

### DIFF
--- a/attendance-ios/Source/Common/BaseViewModel.swift
+++ b/attendance-ios/Source/Common/BaseViewModel.swift
@@ -142,6 +142,7 @@ private extension BaseViewModel {
                             switch result {
                             case .success:
                                 self.userDefaultsWorker.removeAppleId()
+                                self.userDefaultsWorker.setKakaoTalkId(id: kakaoId)
                                 self.output.goToHome.accept(())
                             case .failure: self.output.goToSignUp.accept(())
                             }


### PR DESCRIPTION
## 개요
- #182 애플 회원가입 -> 카카오 로그인 -> 애플 로그인시 홈으로 이동되지 않는 문제

## 문제점
- 애플 회원가입 후 카카오 로그인시 문서 업데이트 후 userDefaults에 카카오키를 저장하도록 설정